### PR TITLE
Gym add fav gym, like/dislike function

### DIFF
--- a/data/gym.js
+++ b/data/gym.js
@@ -165,23 +165,23 @@ const getByGymOwnerId = async (gymOwnerId) => {
   return await gymsDBConnection.find({ gymOwnerId: gymOwnerId });
 };
 
-const updateLikedGymsCnt = async (id) => {
+const updateLikedGymsCnt = async (id, change) => {
   await validation.checkObjectId(id);
   const gymsDBConnection = await gymCollection();
   let updateOne = await gymsDBConnection.updateOne(
     { _id: new ObjectId(id) },
-    { $inc: { likedGymsCnt: 1 } }
+    { $inc: { likedGymsCnt: change } }
   );
   if (updateOne.matchedCount === 0)
     throw [404, `Could not update likedGymsCnt in gym: ${id}`];
 };
 
-const updateDislikedGymsCnt = async (id) => {
+const updateDislikedGymsCnt = async (id, change) => {
   await validation.checkObjectId(id);
   const gymsDBConnection = await gymCollection();
   let updateOne = await gymsDBConnection.updateOne(
     { _id: new ObjectId(id) },
-    { $inc: { dislikedGymsCnt: 1 } }
+    { $inc: { dislikedGymsCnt: change } }
   );
   if (updateOne.matchedCount === 0)
     throw [404, `Could not update dislikedGymsCnt in gym: ${id}`];

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 const middleware = {
     authenticated: (req, res, next) => {
         if (!req.session.userId) {
-            res.status(401).redirect("/users/login");
+            res.status(401).redirect("/user/login");
             return;
         }
         next();

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -14,7 +14,7 @@ router.route('/new/:id').post(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     // get the gym for singleGym page
     let reviewId = req.params.id;
@@ -54,7 +54,7 @@ router.route('/update/:id').put(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let commentId = req.params.id;
     let updatedComment = req.body;
@@ -88,7 +88,7 @@ router.route('/delete/:id').delete(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
 
     let commentId = req.params.id;

--- a/routes/gym.js
+++ b/routes/gym.js
@@ -57,11 +57,11 @@ router.route('/manage').get(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let checkIfGymOwner = helpers.checkIfGymOwner(req);
     if (!checkIfGymOwner) {
-      // res.status(401).redirect("/users/profile");
+      // res.status(401).redirect("/user/profile");
       return res.status(403).json({ error: 'You must be a gym owner to add a gym' });
     }
 
@@ -85,11 +85,11 @@ router.route('/add').post(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let checkIfGymOwner = helpers.checkIfGymOwner(req);
     if (!checkIfGymOwner) {
-      // res.status(401).redirect("/users/profile");
+      // res.status(401).redirect("/user/profile");
       return res.status(403).json({ error: 'You must be a gym owner to add a gym' });
     }
 
@@ -112,11 +112,11 @@ router.route('/delete/:gymId').delete(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let checkIfGymOwner = helpers.checkIfGymOwner(req);
     if (!checkIfGymOwner) {
-      // res.status(401).redirect("/users/profile");
+      // res.status(401).redirect("/user/profile");
       return res.status(403).json({ error: 'You must be a gym owner to add a gym' });
     }
     const gymOwnerId = req.session.userId;
@@ -137,11 +137,11 @@ router.route('/edit/:gymId').put(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let checkIfGymOwner = helpers.checkIfGymOwner(req);
     if (!checkIfGymOwner) {
-      // res.status(401).redirect("/users/profile");
+      // res.status(401).redirect("/user/profile");
       return res.status(403).json({ error: 'You must be a gym owner to add a gym' });
     }
     const gymOwnerId = req.session.userId;
@@ -174,15 +174,97 @@ router.route('/edit/:gymId').put(async (req, res) => {
 });
 
 // Thumb up in gym detail page
-router.route('/:id/like').post(async (req, res) => {
+router.route('/:gymId/like').post(async (req, res) => {
   try {
+    await validation.checkObjectId(req.params.gymId);
+    const gymId = req.params.gymId.toString();
+
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      return res.redirect("/user/loginPage");
     }
-    await validation.checkObjectId(req.params.id);
-    await gymData.updateLikedGymsCnt(req.params.id);
-    res.status(200).redirect("`/gym/${gymId}`");
+    const userId = req.session.userId;
+    const user = await userData.getByUserId(userId)
+    if (!user) {
+      throw [400, `ERROR: User not found`];
+    }
+    let userLikeList = user.likedGyms;
+    let userDislikeList = user.dislikedGyms
+
+    if (userDislikeList.includes(gymId)){
+      let indexToRemove = userDislikeList.indexOf(gymId);
+      if (indexToRemove !== -1) {
+        userDislikeList.splice(indexToRemove, 1);
+        await gymData.updateDislikedGymsCnt(gymId, -1);
+      }
+    }
+    if (!userLikeList.includes(gymId)){
+      userLikeList.push(gymId);
+      await gymData.updateLikedGymsCnt(gymId, 1);
+    }else {
+      let indexToRemove = userLikeList.indexOf(gymId);
+      if (indexToRemove !== -1) {
+        userLikeList.splice(indexToRemove, 1);
+        await gymData.updateLikedGymsCnt(gymId, -1);
+      }
+    }
+
+    user.likedGyms = userLikeList;
+    user.dislikedGyms = userDislikeList;
+
+    await userData.update(userId, user);
+
+    return res.status(200).json({ message: `Success Liked gym ${gymId}` });
+
+  } catch (e) {
+    let status = e[0] ? e[0] : 500;
+    let message = e[1] ? e[1] : 'Internal Server Error';
+    return res.status(status).json({ error: message });
+  }
+});
+
+// Thumb down in gym detail page
+router.route('/:gymId/dislike').post(async (req, res) => {
+  try {
+    await validation.checkObjectId(req.params.gymId);
+    const gymId = req.params.gymId.toString();
+
+    let userLoggedIn = helpers.checkIfLoggedIn(req);
+    if (!userLoggedIn) {
+      return res.status(401).redirect("/user/loginPage");
+    }
+    const userId = req.session.userId;
+    const user = await userData.getByUserId(userId)
+    if (!user) {
+      throw [400, `ERROR: User not found`];
+    }
+    let userLikeList = user.likedGyms;
+    let userDislikeList = user.dislikedGyms
+
+    if (userLikeList.includes(gymId)){
+      let indexToRemove = userLikeList.indexOf(gymId);
+      if (indexToRemove !== -1) {
+        userLikeList.splice(indexToRemove, 1);
+        await gymData.updateLikedGymsCnt(gymId, -1);
+      }
+    }
+    if (!userDislikeList.includes(gymId)){
+      userDislikeList.push(gymId);
+      await gymData.updateDislikedGymsCnt(gymId, 1);
+    }else {
+      let indexToRemove = userDislikeList.indexOf(gymId);
+      if (indexToRemove !== -1) {
+        userDislikeList.splice(indexToRemove, 1);
+        await gymData.updateDislikedGymsCnt(gymId, -1);
+      }
+    }
+
+    user.likedGyms = userLikeList;
+    user.dislikedGyms = userDislikeList;
+
+    await userData.update(userId, user);
+
+    return res.status(200).json({ message: `Success DisLiked gym ${gymId}` });
   } catch (e) {
     let status = e[0] ? e[0] : 500;
     let message = e[1] ? e[1] : 'Internal Server Error';
@@ -190,20 +272,34 @@ router.route('/:id/like').post(async (req, res) => {
   }
 });
 
-// Thumb down in gym detail page
-router.route('/:id/dislike').post(async (req, res) => {
+
+router.route('/:gymId/addFav').post(async (req, res) => {
   try {
+    const gymId = req.params.gymId.toString();
+
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      return res.status(401).redirect("/user/loginPage");
     }
-    await validation.checkObjectId(req.params.id);
-    await gymData.updateDislikedGymsCnt(req.params.id);
-    res.status(200).redirect("`/gym/${gymId}`");
+
+    const userId = req.session.userId;
+    const user = await userData.getByUserId(userId)
+    if (!user) {
+      throw [400, `ERROR: User not found`];
+    }
+
+    let favList = user.favGymList;
+    if (!favList.includes(gymId)){
+      favList.push(gymId);
+      user.favGymList = favList;
+      await userData.update(userId, user);
+    }
+    return  res.status(200).json({ message: 'Success add favList' });
   } catch (e) {
     let status = e[0] ? e[0] : 500;
     let message = e[1] ? e[1] : 'Internal Server Error';
-    res.status(status).json({ error: message });
+    return res.status(status).json({ error: message });
   }
 });
+
 export default router;

--- a/routes/review.js
+++ b/routes/review.js
@@ -21,7 +21,7 @@ router.route('/new/:id').post(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     // get the gym, for rendering the singleGym page
     let gym = await gymData.getByGymId(req.params.id);
@@ -62,7 +62,7 @@ router.route('/updateContent/:id').put(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     // get the gym, for rendering the singleGym page
     let reviewId = req.params.id;
@@ -107,7 +107,7 @@ router.route('/updateRating/:id').put(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     // get the gym, for rendering the singleGym page
     let reviewId = req.params.id;
@@ -152,7 +152,7 @@ router.route('/delete/:id').delete(async (req, res) => {
   try {
     let userLoggedIn = helpers.checkIfLoggedIn(req);
     if (!userLoggedIn) {
-      res.status(401).redirect("/users/login");
+      res.status(401).redirect("/user/login");
     }
     let reviewId = req.params.id;
     reviewId = validation.checkObjectId(reviewId);

--- a/routes/user.js
+++ b/routes/user.js
@@ -21,6 +21,16 @@ router.route('/login').get(async (req, res) => {
   }
 });
 
+// Alternate rout for login, since the POST and GET in the same url /login
+router.route('/loginPage').get(async (req, res) => {
+  //console.log(req.body);
+  if (helpers.checkIfLoggedIn(req)) {
+    res.redirect("/user/profile");
+  } else {
+    res.render('login', { title: 'Gym User Login' });
+  }
+});
+
 router.route('/logout').get(async (req, res) => {
   req.session.destroy(function (err) {
     console.log("User logged out");


### PR DESCRIPTION
1. The redirect URL bug for users has been fixed.

2. A new function has been added to allow users to add their favorite gym. To use this function, pass in the gymId as a parameter and the userId will be retrieved from the session.
/:gymId/like POST

3. The like and dislike routes have been added. To use these routes, pass in the gymId as a parameter. Here is how the logic works:
/:gymId/dislike  POST
/:gymId/like       POST
- Only logged-in users can use these routes. If not, they will be redirected to the login page.
- Like the gym:
  - If the gym has already been liked, the like will be cancelled and the gym will return to a neutral state.
  - If the gym has already been disliked, the dislike will be cancelled and the gym will return to a neutral state.
  - If the gym is in a neutral state (not liked or disliked), then the gym will be liked.
- Dislike the gym:
  - If the gym has already been disliked, the dislike will be cancelled and the gym will return to a neutral state.
  - If the gym has already been liked, the like will be cancelled and the gym will return to a neutral state.
  - If the gym is in a neutral state (not liked or disliked), then the gym will be disliked.
