### PR TITLE
Frontend: fix singleGym page routes

### DIFF
--- a/views/singleGym.handlebars
+++ b/views/singleGym.handlebars
@@ -4,7 +4,11 @@
         <h2>{{gym.gymName}}</h2>
         {{#if userLoggedIn}}
         <div class="pull-right">
-            <input type="button" value="Add to Favorites" class="btn btn-sm btn-primary" />
+            <form id="AddToFavorites" method="POST" action="/gym/{{gym._id}}/addFav/">
+                <button type="submit" value="Add to Favorites" class="btn btn-sm btn-primary">Add
+                    to Favorites</button>
+            </form>
+
             <input type="button" onclick="location.href = '/review/new/{{gym._id}}'" ; value="Post a New Review"
                 class="btn btn-sm btn-dark" />
         </div>
@@ -22,11 +26,16 @@
             <div><span class="bold">Website:</span> {{gym.website}}</div>
         </div>
         <div>
-            <input class="btnLikeGym btn btn-sm btn-success" type="button" data-gymid={{gym._id}}
-                value="Like ({{gym.likedGymsCnt}})" {{#unless userLoggedIn}}disabled{{/unless}} />
-
-            <input class="btnDislikeGym btn btn-sm btn-danger" type="button" data-gymid={{gym._id}}
-                value="Dislike ({{gym.dislikedGymsCnt}})" {{#unless userLoggedIn}}disabled{{/unless}} />
+            <form id="LikeGym" method="POST" action="/gym//{{gym._id}}/like" {{#unless
+                userLoggedIn}}disabled{{/unless}}>
+                <button type="submit" class="btnLikeGym btn btn-sm btn-success">
+                    Like ({{gym.likedGymsCnt}})</button>
+            </form>
+            <form id="dislikeGym" method="POST" action="/gym//{{gym._id}}/dislike" {{#unless
+                userLoggedIn}}disabled{{/unless}}>
+                <button type="submit" class="btnDislikeGym btn btn-sm btn-danger">Dislike
+                    ({{gym.dislikedGymsCnt}})</button>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
For Xinxuan: I have linked the frontend to your gym/like, dislike, add to favorite. However after hit any of the buttons, the routes does not render any html, but instead only return a JSON. Please render all necessary info into either SingleGym page (if successfully), or an error page if it does not. Don't think any routes should return a res.json. 

For Amit: previously the input of like, dislike, fav were not working because, in order to POST to a route (instead of get), a form is probably the best way to do so instead of a input. What's more, previously there were no link for the routes thus it was not fire. I have adjusted this, but please refer to the routes specs when adding any href of input or action in the form.

For frontend: user should be able to see the like of favorite gyms.This feature is still missing. Please implement it asap.